### PR TITLE
Add magick comment to erb template

### DIFF
--- a/lib/autodoc/configuration.rb
+++ b/lib/autodoc/configuration.rb
@@ -16,6 +16,7 @@ module Autodoc
     def reset
       @headers = %w[location]
       @template = <<-EOF.strip_heredoc
+        <%# coding: UTF-8 -%>
         ## <%= method %> <%= path %>
         <%= description %>
         <%= parameters_section %>


### PR DESCRIPTION
This PR will fix Encoding::InvalidByteSequenceError that occurs when the document contains utf-8 chars in Ruby 1.9.

```
/Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/autodoc-0.1.8/lib/autodoc.rb:35:in `write': "\xE3" on US-ASCII (Encoding::InvalidByteSequenceError)
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/autodoc-0.1.8/lib/autodoc.rb:35:in `<<'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/autodoc-0.1.8/lib/autodoc.rb:35:in `block (4 levels) in <top (required)>'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/autodoc-0.1.8/lib/autodoc.rb:35:in `open'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/autodoc-0.1.8/lib/autodoc.rb:35:in `open'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/autodoc-0.1.8/lib/autodoc.rb:35:in `block (3 levels) in <top (required)>'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/autodoc-0.1.8/lib/autodoc.rb:29:in `each'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/autodoc-0.1.8/lib/autodoc.rb:29:in `block (2 levels) in <top (required)>'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:470:in `instance_eval'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/rspec-core-2.13.1/lib/rspec/core/example_group.rb:470:in `instance_eval_with_rescue'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:31:in `run'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:66:in `block in run'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:66:in `each'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:66:in `run'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/rspec-core-2.13.1/lib/rspec/core/hooks.rb:418:in `run_hook'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:30:in `block in run'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/rspec-core-2.13.1/lib/rspec/core/reporter.rb:34:in `report'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/rspec-core-2.13.1/lib/rspec/core/command_line.rb:25:in `run'
        from /Users/ryutaro/Developments/myproject/vendor/bundle/ruby/1.9.1/gems/rspec-core-2.13.1/lib/rspec/core/runner.rb:80:in `run'
```
