### PR TITLE
Make Rspec 3 compliant

### DIFF
--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -11,13 +11,14 @@ module Autodoc
       new(*args).render
     end
 
-    def initialize(context)
+    def initialize(context, example)
       @context = context
+      @example = example
     end
 
     def pathname
       @path ||= begin
-        payload = @context.example.file_path.gsub(%r<\./spec/requests/(.+)_spec\.rb>, '\1.md')
+        payload = @example.file_path.gsub(%r<\./spec/requests/(.+)_spec\.rb>, '\1.md')
         Pathname.new(Autodoc.configuration.path) + payload
       end
     end
@@ -173,12 +174,12 @@ module Autodoc
       if @context.respond_to?(:description)
         @context.description.strip_heredoc
       else
-        "#{@context.example.description.capitalize}."
+        "#{@example.description.capitalize}."
       end
     end
 
     def path
-      @context.example.full_description[%r<(GET|POST|PUT|DELETE) ([^ ]+)>, 2]
+      @example.full_description[%r<(GET|POST|PUT|DELETE) ([^ ]+)>, 2]
     end
 
     def parameters_section

--- a/lib/autodoc/documents.rb
+++ b/lib/autodoc/documents.rb
@@ -6,8 +6,8 @@ module Autodoc
       @table = Hash.new {|table, key| table[key] = [] }
     end
 
-    def append(context)
-      document = Autodoc::Document.new(context.clone)
+    def append(context, example)
+      document = Autodoc::Document.new(context.clone, example.clone)
       @table[document.pathname] << document
     end
 

--- a/lib/autodoc/rspec.rb
+++ b/lib/autodoc/rspec.rb
@@ -1,7 +1,12 @@
 require "rspec"
 
 RSpec.configuration.after(:each, autodoc: true) do
-  Autodoc.documents.append(self)
+  example = if RSpec.respond_to?(:current_example) #RSpec 3~
+    RSpec.current_example
+  else
+    self.example
+  end
+  Autodoc.documents.append(self, example)
 end
 
 RSpec.configuration.after(:suite) do

--- a/spec/requests/entries_spec.rb
+++ b/spec/requests/entries_spec.rb
@@ -29,7 +29,7 @@ describe "Entries" do
   end
 
   describe "GET /entries" do
-    context "with Rack::Test", :autodoc do
+    context "with Rack::Test", autodoc: true do
       it "returns entries" do
         get "/entries", params, env
         last_response.status.should == 200

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -14,7 +14,7 @@ describe "Recipes" do
       Recipe.create(name: "test", type: 2)
     end
 
-    context "with valid condition (using Rack::Test)", :autodoc do
+    context "with valid condition (using Rack::Test)", autodoc: true do
       before do
         env["Content-Type"] = "application/json"
       end
@@ -67,7 +67,7 @@ describe "Recipes" do
       end
     end
 
-    context "with valid condition", :autodoc do
+    context "with valid condition", autodoc: true do
       let(:description) do
         <<-EOS
           Creates

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../../spec/dummy/config/environment", __FILE__)
 require "rspec/rails"
-require "rspec/autorun"
 
 Autodoc.configuration.toc = true
 Autodoc.configuration.path = "spec/dummy/doc"
@@ -16,6 +15,4 @@ RSpec.configure do |config|
   # automatically. This will be the default behavior in future versions of
   # rspec-rails.
   config.infer_base_class_for_anonymous_controllers = false
-
-  config.treat_symbols_as_metadata_keys_with_true_values = true
 end


### PR DESCRIPTION
As of RSpec 3, we can't call example in test.
see discussion: https://github.com/rspec/rspec-core/pull/666

Rough but work at least...
