### PR TITLE
Fix TOC link path

### DIFF
--- a/lib/autodoc/templates/toc.md.erb
+++ b/lib/autodoc/templates/toc.md.erb
@@ -1,11 +1,12 @@
 <%# coding: UTF-8 -%>
 ## Table of Contents
 <% @table.sort.each do |pathname, documents| -%>
-* [<%= pathname.basename %>](<%= pathname.basename %>)
+<% relative_path = pathname.relative_path_from(Pathname.new(Autodoc.configuration.path)) -%>
+* [<%= relative_path %>](<%= relative_path %>)
 <% documents.group_by(&:title).each do |title, documents| -%>
 <% documents.each_with_index do |document, index| -%>
 <% suffix = index == 0 ? "" : "-#{index}" -%>
- * [<%= title %>](<%= "#{pathname.basename}##{document.identifier}#{suffix}" %>)
+ * [<%= title %>](<%= "#{relative_path}##{document.identifier}#{suffix}" %>)
 <% end -%>
 <% end -%>
 <% end -%>

--- a/spec/autodoc/documents_spec.rb
+++ b/spec/autodoc/documents_spec.rb
@@ -10,7 +10,7 @@ describe Autodoc::Documents do
       @documents.append(double(:context))
     end
 
-    describe "GET /recipes in ./recipes.md" do
+    describe "renders 'GET /recipes' in ./recipes.md" do
       let(:title) { "GET /recipes" }
       let(:pathname) { "./recipes.md" }
 
@@ -19,7 +19,7 @@ describe Autodoc::Documents do
       it { should include("[GET /recipes](recipes.md#get-recipes)") }
     end
 
-    describe "GET /admin/recipes in ./admin/recipes.md" do
+    describe "renders 'GET /admin/recipes' in ./admin/recipes.md" do
       let(:title) { "GET /admin/recipes" }
       let(:pathname) { "./admin/recipes.md" }
 

--- a/spec/dummy/doc/admin/entries.md
+++ b/spec/dummy/doc/admin/entries.md
@@ -1,0 +1,23 @@
+## GET /admin/entries
+Returns entries.
+
+### Example
+```
+GET /admin/entries HTTP/1.1
+Accept: application/json
+Content-Length: 0
+Host: example.org
+```
+
+```
+HTTP/1.1 200
+Content-Length: 45
+Content-Type: application/json
+
+[
+  {
+    "title": "Test Title",
+    "body": "Lorem Ipsum"
+  }
+]
+```

--- a/spec/dummy/doc/recipes.md
+++ b/spec/dummy/doc/recipes.md
@@ -14,11 +14,11 @@ HTTP/1.1 200
 Cache-Control: max-age=0, private, must-revalidate
 Content-Length: 111
 Content-Type: application/json; charset=utf-8
-ETag: "817f9446a34cdb5179ee09b555b507f8"
+ETag: "d2bb4f3624c215dcc71b683ec7d58ebd"
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: a1723cc5-c4f7-4779-8382-5dbf879687e5
-X-Runtime: 0.017503
+X-Request-Id: 5f84d51d-9709-4a8f-a02c-77732902252b
+X-Runtime: 0.013851
 X-UA-Compatible: chrome=1
 X-XSS-Protection: 1; mode=block
 
@@ -26,8 +26,8 @@ X-XSS-Protection: 1; mode=block
   "id": 1,
   "name": "test",
   "type": 2,
-  "created_at": "2013-12-18T06:33:23.129Z",
-  "updated_at": "2013-12-18T06:33:23.129Z"
+  "created_at": "2013-12-29T14:22:59.625Z",
+  "updated_at": "2013-12-29T14:22:59.625Z"
 }
 ```
 
@@ -61,12 +61,12 @@ HTTP/1.1 201
 Cache-Control: max-age=0, private, must-revalidate
 Content-Length: 111
 Content-Type: application/json; charset=utf-8
-ETag: "9a32ff7207d60c4e3eca833ed83320f9"
+ETag: "0d698f869368039f2145c92927b36720"
 Location: http://www.example.com/recipes/1
 X-Content-Type-Options: nosniff
 X-Frame-Options: SAMEORIGIN
-X-Request-Id: 06f2dfe3-3085-419a-b2a8-db3abd1d3156
-X-Runtime: 0.006099
+X-Request-Id: 84349101-dc40-4416-83a0-a767242881f9
+X-Runtime: 0.003861
 X-UA-Compatible: chrome=1
 X-XSS-Protection: 1; mode=block
 
@@ -74,7 +74,7 @@ X-XSS-Protection: 1; mode=block
   "id": 1,
   "name": "name",
   "type": 1,
-  "created_at": "2013-12-18T06:33:23.195Z",
-  "updated_at": "2013-12-18T06:33:23.195Z"
+  "created_at": "2013-12-29T14:22:59.676Z",
+  "updated_at": "2013-12-29T14:22:59.676Z"
 }
 ```

--- a/spec/dummy/doc/toc.md
+++ b/spec/dummy/doc/toc.md
@@ -1,4 +1,6 @@
 ## Table of Contents
+* [admin/entries.md](admin/entries.md)
+ * [GET /admin/entries](admin/entries.md#get-adminentries)
 * [entries.md](entries.md)
  * [GET /entries](entries.md#get-entries)
 * [recipes.md](recipes.md)

--- a/spec/requests/admin/entries_spec.rb
+++ b/spec/requests/admin/entries_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe "Admin::Entries" do
+  include Rack::Test::Methods
+
+  let(:env) do
+    { "HTTP_ACCEPT" => "application/json" }
+  end
+
+  let(:params) do
+    {}
+  end
+
+  let(:app) do
+    lambda do |env|
+      [
+        200,
+        { "Content-Type" => "application/json" },
+        [
+          [
+            {
+              title: "Test Title",
+              body: "Lorem Ipsum",
+            },
+          ].to_json,
+        ],
+      ]
+    end
+  end
+
+  describe "GET /admin/entries" do
+    context "with Rack::Test", :autodoc do
+      it "returns entries" do
+        get "/admin/entries", params, env
+        last_response.status.should == 200
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi.
This PR fixes link paths in TOC.md and add some spec.

We sometimes use sub-directories in request spec dir.
For example, like this:

```
spec/
 requests/
   api/
     entries_spec.rb
     ...
```

And  Autodoc outputs files like below:

```
doc/
  toc.md
  admin/
    entries.md
```

But `toc.md` link path is broken:

```
## Table of Contents
* [entries.md](entries.md)
 * [GET /admin/entries](entries.md#get-adminentries)
```

My expected output is below:

```
## Table of Contents
* [admin/entries.md](admin/entries.md)
 * [GET /admin/entries](entries.md#get-adminentries)
```
