### PR TITLE
Add header template

### DIFF
--- a/lib/autodoc/configuration.rb
+++ b/lib/autodoc/configuration.rb
@@ -30,8 +30,16 @@ module Autodoc
       File.read(File.expand_path("../templates/document.md.erb", __FILE__))
     end
 
+    property :header_template do
+      File.read(File.expand_path("../templates/header.md.erb", __FILE__))
+    end
+
     property :toc_template do
       File.read(File.expand_path("../templates/toc.md.erb", __FILE__))
+    end
+
+    property :header do
+      false
     end
 
     property :toc do

--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -34,6 +34,22 @@ module Autodoc
       title.gsub(" ", "-").gsub(/[:\/]/, "").downcase
     end
 
+    def method
+      request.method
+    end
+
+    def resource
+      path
+    end
+
+    def description
+      if @context.respond_to?(:description)
+        @context.description.strip_heredoc
+      else
+        "#{@context.example.description.capitalize}."
+      end
+    end
+
     private
 
     def request
@@ -56,9 +72,9 @@ module Autodoc
       end
     end
 
-    def method
-      request.method
-    end
+    # def method
+    #   request.method
+    # end
 
     def request_header
       table = request_header_from_fixed_keys
@@ -169,13 +185,13 @@ module Autodoc
       @transaction ||= Autodoc::Transaction.build(@context)
     end
 
-    def description
-      if @context.respond_to?(:description)
-        @context.description.strip_heredoc
-      else
-        "#{@context.example.description.capitalize}."
-      end
-    end
+    # def description
+    #   if @context.respond_to?(:description)
+    #     @context.description.strip_heredoc
+    #   else
+    #     "#{@context.example.description.capitalize}."
+    #   end
+    # end
 
     def path
       @context.example.full_description[%r<(GET|POST|PUT|DELETE) ([^ ]+)>, 2]

--- a/lib/autodoc/documents.rb
+++ b/lib/autodoc/documents.rb
@@ -21,7 +21,10 @@ module Autodoc
     def write_documents
       @table.each do |pathname, documents|
         pathname.parent.mkpath
-        pathname.open("w") {|file| file << documents.map(&:render).join("\n").rstrip + "\n" }
+        pathname.open("w") do |file|
+          file << ERB.new(Autodoc.configuration.header_template, nil, "-").result(binding) + "\n" if Autodoc.configuration.header
+          file << documents.map(&:render).join("\n").rstrip + "\n"
+        end
       end
     end
 

--- a/lib/autodoc/templates/header.md.erb
+++ b/lib/autodoc/templates/header.md.erb
@@ -1,0 +1,2 @@
+<%# coding: UTF-8 -%>
+# <%= pathname.basename(".*").to_s.capitalize %>


### PR DESCRIPTION
Create a document from the test is a great idea.
It is wonderful to be in the document table of contents.

So I looked at the template header.
Please check the example.
http://ogom.github.io/natsume-rails-example/docs/api/v1/products.html
https://github.com/ogom/natsume-rails-example#jekyll-with-autodoc