### PR TITLE
For RSpec 2.99

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ group :test do
   gem "pry-rails"
   if ENV['RSPEC2']
     gem "rspec-rails", "~> 2.14.1"
+  elsif ENV['RSPEC299']
+    gem "rspec-rails", "~> 2.99.0"
   else
     gem "rspec-rails"
   end

--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -38,7 +38,7 @@ module Autodoc
     private
 
     def example
-      if ::RSpec::Core::Version::STRING.split('.').first == "3"
+      if ::RSpec::Core::Version::STRING.match /\A(?:3\.|2.99\.)/
         @example
       else
         @context.example

--- a/spec/autodoc/documents_spec.rb
+++ b/spec/autodoc/documents_spec.rb
@@ -30,7 +30,14 @@ describe Autodoc::Documents do
     end
 
     let(:example) do
-      double(file_path: file_path, full_description: full_description)
+      mock = double(file_path: file_path, full_description: full_description)
+
+      if ::RSpec::Core::Version::STRING.split('.').first == "3"
+        allow(mock).to receive_messages(clone: mock)
+      else
+        mock.stub(clone: mock)
+      end
+      mock
     end
 
     let(:file_path) do

--- a/spec/autodoc/documents_spec.rb
+++ b/spec/autodoc/documents_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Autodoc::Documents do
   describe "#render_toc" do
     before do
-      if ::RSpec::Core::Version::STRING.split('.').first == "3"
+      if ::RSpec::Core::Version::STRING.match /\A(?:3\.|2.99\.)/
         documents.append(context, example)
       else
         documents.append(context, double)
@@ -15,7 +15,7 @@ describe Autodoc::Documents do
     end
 
     let(:context) do
-      if ::RSpec::Core::Version::STRING.split('.').first == "3"
+      if ::RSpec::Core::Version::STRING.match /\A(?:3\.|2.99\.)/
         mock = double(example: example, request: request, file_path: file_path, full_description: full_description)
       else
         mock = double(example: example, request: request)


### PR DESCRIPTION
RSpec 2.99 is not completely compatible RSpec 2. 
I split example object from context as with Rspec 3 support.
When test by RSpec 2.99, use RSPEC299 environment variable.

```
RSPEC299=1 bundle install
RSPEC299=1 bundle exec rspec # all tests are passed
```
