### PR TITLE
Add generation of single page html documentation with table of contents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,5 @@ group :test do
   gem "weak_parameters"
   gem "protected_attributes"
   gem "rack-test"
+  gem "redcarpet"
 end

--- a/README.md
+++ b/README.md
@@ -75,10 +75,14 @@ You can configure `Autodoc.configuration` to change its behavior:
 * template - [String] ERB template for each document (default: [document.md.erb](https://github.com/r7kamura/autodoc/blob/master/lib/autodoc/templates/document.md.erb))
 * toc_template - [String] ERB template for ToC (default: [toc.md.erb](https://github.com/r7kamura/autodoc/blob/master/lib/autodoc/templates/toc.md.erb))
 * toc - [Boolean] whether to generate toc.md (default: false)
+* toc_html_template - [String] ERB template for html ToC (default: [toc.html.erb](https://github.com/r7kamura/autodoc/blob/master/lib/autodoc/templates/toc.html.erb))
+* toc_html - [Boolean] whether to generate toc.html - a single page documentation with a toc (default: false)
 
 ```ruby
 # example
 Autodoc.configuration.path = "doc/api"
 Autodoc.configuration.toc = true
+Autodoc.configuration.toc_html = true
 Autodoc.configuration.template = File.read(File.expand_path("../autodoc/templates/document.md.erb", __FILE__))
+
 ```

--- a/lib/autodoc/configuration.rb
+++ b/lib/autodoc/configuration.rb
@@ -34,6 +34,14 @@ module Autodoc
       File.read(File.expand_path("../templates/toc.md.erb", __FILE__))
     end
 
+    property :toc_html do
+      false
+    end
+
+    property :toc_html_template do
+      File.read(File.expand_path("../templates/toc.html.erb", __FILE__))
+    end
+
     property :toc do
       false
     end

--- a/lib/autodoc/documents.rb
+++ b/lib/autodoc/documents.rb
@@ -13,6 +13,8 @@ module Autodoc
 
     def write
       write_toc if Autodoc.configuration.toc
+      write_toc_html if Autodoc.configuration.toc_html
+
       write_documents
     end
 
@@ -34,8 +36,21 @@ module Autodoc
       ERB.new(Autodoc.configuration.toc_template, nil, "-").result(binding)
     end
 
+     def write_toc_html
+      toc_html_path.parent.mkpath
+      toc_html_path.open("w") {|file| file << render_toc_html }
+    end
+
+    def render_toc_html
+      ERB.new(Autodoc.configuration.toc_html_template, nil, "-").result(binding)
+    end
+
     def toc_path
       Autodoc.configuration.pathname + "toc.md"
+    end
+
+    def toc_html_path
+      Autodoc.configuration.pathname + "toc.html"
     end
   end
 end

--- a/lib/autodoc/templates/toc.html.erb
+++ b/lib/autodoc/templates/toc.html.erb
@@ -1,0 +1,82 @@
+<%# coding: UTF-8 -%>
+<head>
+  <style>
+    .api-docs {
+      left: 210px;
+    }
+
+    .api-docs, .api-docs-toc {
+      width: 66%;
+     }
+
+     .api-action {
+       padding: 10px;
+     }
+
+    .tocify-wrapper {
+      overflow-y: auto;
+      overflow-x: hidden;
+      position: fixed;
+      width: 210px;
+      float: left;
+      font-size: 16px;
+      background-color: #AAAADD;
+      top: 1px;
+      bottom: -1px;
+      padding: 10px;
+    }
+
+    .generated-at {
+      position: fixed;
+      bottom: 10px;
+    }
+
+    .api-resource {
+      border-bottom: black 1px solid;
+    }
+
+    pre {
+      padding: 10px;
+      background-color: #CCCCEE;
+    }
+
+    .page-wrapper {
+      margin-left: 240px;
+      min-width: 700px;
+      position: relative;
+      z-index: 10;
+    }
+  </style>
+</head>
+<% markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, {fenced_code_blocks: true}) %>
+<% document_markdown = '' %>
+<html>
+<div class='tocify-wrapper'>
+<h1> Table of Contents </h1>
+<% @table.sort.each do |pathname, documents| -%>
+  <% title = pathname.cleanpath.to_s.sub(/^.*doc\//,'') -%>
+  <% link = pathname.to_s.html_safe -%>
+  <li>
+    <a href="#<%= link -%>"><%= title -%></a>
+  </li>
+  <%
+    document_markdown += '<div id="' + pathname.to_s.html_safe + '" class="api-resource">'
+    documents.each do |document|
+      document_markdown += '<div class="api-action">'
+      document_markdown += markdown.render(document.render)
+      document_markdown += '</div>'
+    end
+    document_markdown += '</div>'
+  %>
+<% end -%>
+<div class='generated-at'>
+Generated at:
+<br>
+<%= Time.now.to_s -%>
+</div>
+</div>
+
+<div class='page-wrapper'>
+  <%= document_markdown -%>
+</div>
+</html>

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "Recipes", type: :request do
-  let(:env) do
+  let(:env_hash) do
     { "ACCEPT" => "application/json", "CONTENT_TYPE" => "application/json" }
   end
 
@@ -16,13 +16,13 @@ describe "Recipes", type: :request do
 
     context "with valid condition (using Rack::Test)", autodoc: true do
       before do
-        env["Content-Type"] = "application/json"
+        env_hash["Content-Type"] = "application/json"
       end
 
       include Rack::Test::Methods
 
       it "returns the recipe" do
-        get "/recipes/#{recipe.id}", params, env
+        get "/recipes/#{recipe.id}", params, env_hash
         expect(last_response.status).to eq(200)
       end
     end
@@ -40,7 +40,7 @@ describe "Recipes", type: :request do
       end
 
       it "returns 400" do
-        post "/recipes", params.to_json, env
+        post "/recipes", params.to_json, env_hash
         expect(response.status).to eq(400)
       end
     end
@@ -51,7 +51,7 @@ describe "Recipes", type: :request do
       end
 
       it "returns 400" do
-        post "/recipes", params.to_json, env
+        post "/recipes", params.to_json, env_hash
         expect(response.status).to eq(400)
       end
     end
@@ -62,7 +62,7 @@ describe "Recipes", type: :request do
       end
 
       it "creates a new recipe" do
-        post "/recipes", params.to_json, env
+        post "/recipes", params.to_json, env_hash
         expect(response.status).to eq(201)
       end
     end
@@ -78,7 +78,7 @@ describe "Recipes", type: :request do
       end
 
       it "creates a new recipe" do
-        post "/recipes", params.to_json, env
+        post "/recipes", params.to_json, env_hash
         expect(response.status).to eq(201)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require File.expand_path("../../spec/dummy/config/environment", __FILE__)
 require "rspec/rails"
 
 Autodoc.configuration.toc = true
+Autodoc.configuration.toc_html = true
 Autodoc.configuration.path = "spec/dummy/doc"
 
 RSpec.configure do |config|


### PR DESCRIPTION
The utility of this should be pretty obvious, its something that I've had to do for projects. You can even make the generated html a partial and style your own css with minimal effort. 

Adding this feature does require adding the RedCarpet gem.   

- see README for configuration details

![screen shot 2015-01-18 at 5 17 53 pm](https://cloud.githubusercontent.com/assets/1488756/5794310/15a9739e-9f36-11e4-8ee0-66fe0d9c66db.png)
