### PR TITLE
support nested parameter

### DIFF
--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -219,13 +219,27 @@ module Autodoc
       end
 
       def to_s
-        "#{body}#{payload}"
+        string = ""
+        string << "#{body}#{payload}"
+
+        if validator.respond_to? :validators
+          validator.validators.each do |x|
+            string << "\n"
+            string << Parameter.new(x).to_s.indent(2)
+          end
+        end
+
+        string
       end
 
       private
 
       def body
-        "* `#{validator.key}` #{validator.type}"
+        if validator.key.nil?
+          "* #{validator.type}"
+        else
+          "* `#{validator.key}` #{validator.type}"
+        end
       end
 
       def payload


### PR DESCRIPTION
Support nested parameters for https://github.com/r7kamura/weak_parameters/pull/13.

## Example

```
### Parameters
* `nested` object (required)
  * `number` integer (only: `[0, 1]`)
    * `numbers` list
      * `0` integer - some numbers
* `items` list
  * object - some items
    * `name` string
    * `price` integer
```