### PR TITLE
Take contexts into account when generating doc.

### DIFF
--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -188,7 +188,11 @@ module Autodoc
       if @context.respond_to?(:description)
         @context.description.strip_heredoc
       else
-        "#{example.description.capitalize}."
+        # Full Description:
+        #   Users POST /api/users/sign_in with context1 when nested context
+        #   should hello
+        # And we want to take the contexts into account.
+        "#{example.full_description.split(' ')[3..-1].join(' ').capitalize}"
       end
     end
 

--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -192,12 +192,16 @@ module Autodoc
         #   Users POST /api/users/sign_in with context1 when nested context
         #   should hello
         # And we want to take the contexts into account.
-        "#{example.full_description.split(' ')[3..-1].join(' ').capitalize}"
+        desc_with_context = example
+          .full_description
+          .match(/(#{supported_methods.join("|")}) (\S+) (.*)/)
+          .to_a[3]
+        "#{desc_with_context.capitalize}"
       end
     end
 
     def path
-      example.full_description[%r<(GET|POST|PATCH|PUT|DELETE) ([^ ]+)>, 2]
+      example.full_description[%r<(#{supported_methods.join('|')}) ([^ ]+)>, 2]
     end
 
     def parameters_section
@@ -272,5 +276,10 @@ module Autodoc
         "except: `#{validator.options[:except].inspect}`" if validator.options[:except]
       end
     end
+
+    private
+      def supported_methods
+        ["GET", "POST", "PATCH", "PUT", "DELETE"]
+      end
   end
 end


### PR DESCRIPTION
Currently when we have something like:

```ruby
RSpec.describe "Users", type: :request do
  describe "POST /api/users/sign_in", autodoc: true do

    context "this is context" do
      context "this is nested context" do
        it "should return token and username" do
          send_request
          expect(response.status).to eq(200)
        end
      end
    end
  end
end
```

the generated doc will only have the description in `it`, i.e.:

```markdown
## POST /api/users/sign_in
should return token and username.
...
```

However, sometimes we need to also put the descriptions of those contexts into the documentation to make it more detailed.

How do you think?

Thanks.