### PR TITLE
add skip config

### DIFF
--- a/lib/autodoc/configuration.rb
+++ b/lib/autodoc/configuration.rb
@@ -46,7 +46,7 @@ module Autodoc
       false
     end
 
-    property :skip do
+    property :ignore_dir do
       ""
     end
 

--- a/lib/autodoc/configuration.rb
+++ b/lib/autodoc/configuration.rb
@@ -46,6 +46,10 @@ module Autodoc
       false
     end
 
+    property :skip do
+      ""
+    end
+
     def pathname
       Pathname.new(path)
     end

--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -19,6 +19,9 @@ module Autodoc
     def pathname
       @path ||= begin
         payload = example.file_path.gsub(%r<\./spec/[^/]+/(.+)_spec\.rb>, '\1.md')
+      unless Autodoc.configuration.skip.empty?
+        payload = payload.sub("#{Autodoc.configuration.skip}/", "")
+      end
         Autodoc.configuration.pathname + payload
       end
     end

--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -19,9 +19,9 @@ module Autodoc
     def pathname
       @path ||= begin
         payload = example.file_path.gsub(%r<\./spec/[^/]+/(.+)_spec\.rb>, '\1.md')
-      unless Autodoc.configuration.skip.empty?
-        payload = payload.sub("#{Autodoc.configuration.skip}/", "")
-      end
+        unless Autodoc.configuration.ignore_dir.empty?
+          payload = payload.sub("#{Autodoc.configuration.ignore_dir}/", "")
+        end
         Autodoc.configuration.pathname + payload
       end
     end

--- a/spec/autodoc/documents_spec.rb
+++ b/spec/autodoc/documents_spec.rb
@@ -82,6 +82,20 @@ describe Autodoc::Documents do
         expect(toc).to include("[admin/recipes.md](admin/recipes.md)")
         expect(toc).to include("[GET /admin/recipes](admin/recipes.md#get-adminrecipes)")
       end
+
+      context "with skip configuration" do
+      around do |example|
+        Autodoc.configuration.skip = "admin"
+        example.run
+        Autodoc.configuration.skip = ""
+      end
+
+      it "includes links to recipes.md" do
+        toc = documents.send(:render_toc)
+        expect(toc).to include("[recipes.md](recipes.md)")
+        expect(toc).to include("[GET /admin/recipes](recipes.md#get-adminrecipes)")
+        end
+      end
     end
   end
 end

--- a/spec/autodoc/documents_spec.rb
+++ b/spec/autodoc/documents_spec.rb
@@ -83,11 +83,11 @@ describe Autodoc::Documents do
         expect(toc).to include("[GET /admin/recipes](admin/recipes.md#get-adminrecipes)")
       end
 
-      context "with skip configuration" do
+      context "with ignore_dir configuration" do
       around do |example|
-        Autodoc.configuration.skip = "admin"
+        Autodoc.configuration.ignore_dir = "admin"
         example.run
-        Autodoc.configuration.skip = ""
+        Autodoc.configuration.ignore_dir = ""
       end
 
       it "includes links to recipes.md" do


### PR DESCRIPTION
When there are test suit like this:

```
spec/requests/api/*_spec.rb
```
sometimes, we want to ignore `api` from the documents.

how do you like it?