### PR TITLE
Delete a space between arrow and args for Ruby 1.9 and 2.0.

### DIFF
--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -7,7 +7,7 @@ require "pathname"
 
 module Autodoc
   class Document
-    DEFAULT_DOCUMENT_PATH_FROM_EXAMPLE = -> (example) do
+    DEFAULT_DOCUMENT_PATH_FROM_EXAMPLE = ->(example) do
       example.file_path.gsub(%r<\./spec/[^/]+/(.+)_spec\.rb>, '\1.md')
     end
 


### PR DESCRIPTION
It couldn't work on Ruby 1.9.3 because of a space between arrow(->) and a bracket of args.
Maybe 2.0.x too.

http://ruby-journal.com/becareful-with-space-in-lambda-hash-rocket-syntax-between-ruby-1-dot-9-and-2-dot-0/

If you don't support Ruby 1.9.x and 2.0.x, please reject this pull request.