### PR TITLE
Don't append pending examples

### DIFF
--- a/lib/autodoc/rspec.rb
+++ b/lib/autodoc/rspec.rb
@@ -1,7 +1,7 @@
 require "rspec"
 
 RSpec.configuration.after(:each, autodoc: true) do |example|
-  Autodoc.documents.append(self, example)
+  Autodoc.documents.append(self, example) unless example.pending?
 end
 
 RSpec.configuration.after(:suite) do

--- a/spec/requests/pending_spec.rb
+++ b/spec/requests/pending_spec.rb
@@ -1,0 +1,7 @@
+require "spec_helper"
+
+describe "Example", type: :request do
+  specify "example spec for pending spec", autodoc: true do
+    skip
+  end
+end


### PR DESCRIPTION
They might respond `nil` object for `request` method call, and that
causes `ArgumentError` for calling `Autodoc::Document#method` because
in that case it means `Object#method` call with no arguments.