### PR TITLE
Rails 4.2 deprecated `serve_static_assets`

### DIFF
--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -11,7 +11,7 @@ Dummy::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = false
+  config.serve_static_files = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -10,7 +10,7 @@ Dummy::Application.configure do
   config.cache_classes = true
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching


### PR DESCRIPTION
DEPRECATION WARNING: The configuration option
`config.serve_static_assets` has been renamed to
`config.serve_static_files` to clarify its role (it merely enables
        serving everything in the `public` folder and is unrelated to
        the asset pipeline). The `serve_static_assets` alias will be
removed in Rails 5.0. Please migrate your configuration files
accordingly.