### PR TITLE
Don't downcase description

### DIFF
--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -195,7 +195,7 @@ module Autodoc
       if @context.respond_to?(:description)
         @context.description.strip_heredoc
       else
-        "#{example.description.capitalize}."
+        example.description.sub(/\A./, &:upcase).concat('.')
       end
     end
 


### PR DESCRIPTION
Since [`AS::Multibyte::Chars#capitalize`](https://github.com/rails/rails/blob/v5.0.0.beta3/activesupport/lib/active_support/multibyte/chars.rb#L145) downcases chars except first one, the description becomes unexpected one. I want to fix it like:

## Input
```rb
it 'enqueues a message to AWS SQS', :autodoc do
  # ...
end
```

## Output
### Expected
```
Enqueues a message to AWS SQS.
```

### Actual
```
Enqueues a message to aws sqs.
```