### PR TITLE
Support multibyte query string

### DIFF
--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -106,7 +106,7 @@ module Autodoc
     end
 
     def request_query
-      "?#{URI.unescape(request.query_string)}" unless request.query_string.empty?
+      "?#{URI.unescape(request.query_string.force_encoding(Encoding::UTF_8))}" unless request.query_string.empty?
     end
 
     def request_body_section


### PR DESCRIPTION
multibyte文字を含むquery stringに対応しました。
`request.query_string`に文字コード`UTF-8`を与えることで対応しています。

issue: https://github.com/r7kamura/autodoc/issues/41
