### PR TITLE
fix indent in toc template

### DIFF
--- a/lib/autodoc/templates/toc.md.erb
+++ b/lib/autodoc/templates/toc.md.erb
@@ -6,7 +6,7 @@
 <% documents.group_by(&:title).each do |title, docs| -%>
 <% docs.each_with_index do |document, index| -%>
 <% suffix = index == 0 ? "" : "-#{index}" -%>
- * [<%= title %>](<%= "#{relative_path}##{document.identifier}#{suffix}" %>)
+  * [<%= title %>](<%= "#{relative_path}##{document.identifier}#{suffix}" %>)
 <% end -%>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Changed indent to 2 spaces in toc template.

If the indent is 1 space, it may not be recognized as indent in the preview display.

ex. [example on github](https://github.com/r7kamura/autodoc/blob/master/spec/dummy/doc/toc.md)
![image](https://user-images.githubusercontent.com/7542105/59611714-c59b1200-9156-11e9-8d42-ce87f0f59234.png)

ref. [CommonMark Spec](https://spec.commonmark.org/0.29/#example-265),  [GitHub Flavored Markdown Spec](https://github.github.com/gfm/#example-273)

