### PR TITLE
Use request_method instead of method

### DIFF
--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -73,7 +73,7 @@ module Autodoc
     end
 
     def method
-      request.method
+      request.request_method
     end
 
     def request_header

--- a/spec/autodoc/documents_spec.rb
+++ b/spec/autodoc/documents_spec.rb
@@ -45,7 +45,7 @@ describe Autodoc::Documents do
     end
 
     let(:request) do
-      double(method: method)
+      double(request_method: method)
     end
 
     let(:method) do


### PR DESCRIPTION
This change improves error message.

### before

```
ArgumentError:
  wrong number of arguments (given 0, expected 1)
```

caused by `Object#method`.

### after

```
NoMethodError:
  undefined method `request_method' for nil:NilClass
```