### PR TITLE
Convert header key to string

### DIFF
--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -87,7 +87,7 @@ module Autodoc
 
     def request_header_from_http_prefix
       request.headers.inject({}) do |table, (key, value)|
-        if key.start_with?("HTTP_")
+        if key.to_s.start_with?("HTTP_")
           table.merge(key.gsub(/^HTTP_/, "") => value)
         else
           table

--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -88,7 +88,7 @@ module Autodoc
     def request_header_from_http_prefix
       request.headers.inject({}) do |table, (key, value)|
         if key.to_s.start_with?("HTTP_")
-          table.merge(key.gsub(/^HTTP_/, "") => value)
+          table.merge(key.to_s.gsub(/^HTTP_/, "") => value)
         else
           table
         end


### PR DESCRIPTION
Some of third party library put env key as Symbol like this one
https://github.com/DataDog/dd-trace-rb/blob/master/lib/ddtrace/contrib/rack/middlewares.rb#L80

So converting every header key as String avoids no method error.
If you have better solution for that, let me know.

Thanks!

@r7kamura 