### PR TITLE
Use URI.decode_www_form_component

### DIFF
--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -106,7 +106,7 @@ module Autodoc
     end
 
     def request_query
-      "?#{URI.unescape(request.query_string.force_encoding(Encoding::UTF_8))}" unless request.query_string.empty?
+      "?#{URI.decode_www_form_component(request.query_string.force_encoding(Encoding::UTF_8))}" unless request.query_string.empty?
     end
 
     def request_body_section


### PR DESCRIPTION
I had an error with Ruby 3.0.1:

```
NoMethodError:
  undefined method `unescape' for URI:Module
# /usr/local/bundle/ruby/3.0.0/gems/autodoc-0.7.5/lib/autodoc/document.rb:109:in `request_query'
# (erb):9:in `render'
# /usr/local/bundle/ruby/3.0.0/gems/autodoc-0.7.5/lib/autodoc/document.rb:30:in `render'
# (erb):93:in `block (2 levels) in render_toc_html'
# (erb):91:in `each'
# (erb):91:in `block in render_toc_html'
# (erb):83:in `each'
# (erb):83:in `render_toc_html'
# /usr/local/bundle/ruby/3.0.0/gems/autodoc-0.7.5/lib/autodoc/documents.rb:45:in `render_toc_html'
# /usr/local/bundle/ruby/3.0.0/gems/autodoc-0.7.5/lib/autodoc/documents.rb:41:in `block in write_toc_html'
# /usr/local/bundle/ruby/3.0.0/gems/autodoc-0.7.5/lib/autodoc/documents.rb:41:in `open'
# /usr/local/bundle/ruby/3.0.0/gems/autodoc-0.7.5/lib/autodoc/documents.rb:41:in `open'
# /usr/local/bundle/ruby/3.0.0/gems/autodoc-0.7.5/lib/autodoc/documents.rb:41:in `write_toc_html'
# /usr/local/bundle/ruby/3.0.0/gems/autodoc-0.7.5/lib/autodoc/documents.rb:16:in `write'
# /usr/local/bundle/ruby/3.0.0/gems/autodoc-0.7.5/lib/autodoc/rspec.rb:8:in `block in <main>'
```