### PR TITLE
Fix `ERB.new` arguments style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Prefer `#media_type` to `#content_type` (for Rails 7's change).
+- Fix `ERB.new` arguments style.
 
 ## 0.7.6
 

--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -27,7 +27,7 @@ module Autodoc
     end
 
     def render
-      ERB.new(Autodoc.configuration.template, nil, "-").result(binding)
+      ERB.new(Autodoc.configuration.template, trim_mode: "-").result(binding)
     end
 
     def title

--- a/lib/autodoc/documents.rb
+++ b/lib/autodoc/documents.rb
@@ -33,7 +33,7 @@ module Autodoc
     end
 
     def render_toc
-      ERB.new(Autodoc.configuration.toc_template, nil, "-").result(binding)
+      ERB.new(Autodoc.configuration.toc_template, trim_mode: "-").result(binding)
     end
 
     def write_toc_html
@@ -42,7 +42,7 @@ module Autodoc
     end
 
     def render_toc_html
-      ERB.new(Autodoc.configuration.toc_html_template, nil, "-").result(binding)
+      ERB.new(Autodoc.configuration.toc_html_template, trim_mode: "-").result(binding)
     end
 
     def toc_path


### PR DESCRIPTION
> warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
