### PR TITLE
出力結果がspecファイルの記述順に合うように修正

### DIFF
--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -21,7 +21,7 @@ module Autodoc
     end
 
     def line_number
-      @context.instance_variable_get(:@__inspect_output)[/:([\d]+)\)$/, 1].to_i
+      @context.inspect[/:([\d]+)\)>$/, 1].to_i
     end
 
     def pathname

--- a/lib/autodoc/document.rb
+++ b/lib/autodoc/document.rb
@@ -20,6 +20,10 @@ module Autodoc
       @example = example
     end
 
+    def line_number
+      @context.instance_variable_get(:@__inspect_output)[/:([\d]+)\)$/, 1].to_i
+    end
+
     def pathname
       @pathname ||= begin
         Autodoc.configuration.pathname + document_path_from_example.call(example)

--- a/lib/autodoc/documents.rb
+++ b/lib/autodoc/documents.rb
@@ -23,7 +23,7 @@ module Autodoc
     def write_documents
       @table.each do |pathname, documents|
         pathname.parent.mkpath
-        pathname.open("w") {|file| file << documents.map(&:render).join("\n").rstrip + "\n" }
+        pathname.open("w") {|file| file << documents.sort_by(&:line_number).map(&:render).join("\n").rstrip + "\n" }
       end
     end
 


### PR DESCRIPTION
```ruby  
describe 'POST /recipes' do

  context 'some description' do

    it 'first test', autodoc: true do
      # ...
    end

  end

  it 'second test', autodoc: true do
    # ...
  end

end
```

このように context ありとなしを混在して記述すると、テストコードの記述順と出力結果の順番が異なる場合があります。
これをテストコードの記述順に合うように修正しました。